### PR TITLE
Replace "is" with "==" to test equality

### DIFF
--- a/biocars/laue.py
+++ b/biocars/laue.py
@@ -115,14 +115,14 @@ class channel_pixels:
 
   from libtbx.development.timers import Profiler
   P = Profiler("nanoBragg")
-  if add_spots_algorithm is "NKS":
+  if add_spots_algorithm=="NKS":
     print ("USING NKS")
     from boost_adaptbx.boost.python import streambuf # will deposit printout into dummy StringIO as side effect
     SIM.add_nanoBragg_spots_nks(streambuf(StringIO()))
-  elif add_spots_algorithm is "JH":
+  elif add_spots_algorithm=="JH":
     print ("USING JH")
     SIM.add_nanoBragg_spots()
-  elif add_spots_algorithm is "cuda":
+  elif add_spots_algorithm=="cuda":
     print ("USING cuda")
     SIM.add_nanoBragg_spots_cuda()
   else: raise Exception("unknown spots algorithm")

--- a/sim/step5_laue.py
+++ b/sim/step5_laue.py
@@ -112,14 +112,14 @@ class channel_pixels:
 
   from libtbx.development.timers import Profiler
   P = Profiler("nanoBragg")
-  if add_spots_algorithm is "NKS":
+  if add_spots_algorithm=="NKS":
     print ("USING NKS")
     from boost_adaptbx.boost.python import streambuf # will deposit printout into dummy StringIO as side effect
     SIM.add_nanoBragg_spots_nks(streambuf(StringIO()))
-  elif add_spots_algorithm is "JH":
+  elif add_spots_algorithm=="JH":
     print ("USING JH")
     SIM.add_nanoBragg_spots()
-  elif add_spots_algorithm is "cuda":
+  elif add_spots_algorithm=="cuda":
     print ("USING cuda")
     SIM.add_nanoBragg_spots_cuda()
   else: raise Exception("unknown spots algorithm")

--- a/sim/step5_pad.py
+++ b/sim/step5_pad.py
@@ -118,12 +118,12 @@ def channel_pixels(wavelength_A,flux,N,UMAT_nm,Amatrix_rot,fmodel_generator,loca
 
   from libtbx.development.timers import Profiler
   P = Profiler("nanoBragg C++ rank %d"%(rank))
-  if add_spots_algorithm is "NKS":
+  if add_spots_algorithm=="NKS":
     from boost_adaptbx.boost.python import streambuf # will deposit printout into dummy StringIO as side effect
     SIM.add_nanoBragg_spots_nks(streambuf(StringIO()))
-  elif add_spots_algorithm is "JH":
+  elif add_spots_algorithm=="JH":
     SIM.add_nanoBragg_spots()
-  elif add_spots_algorithm is "cuda":
+  elif add_spots_algorithm=="cuda":
     SIM.add_nanoBragg_spots_cuda()
   else: raise Exception("unknown spots algorithm")
   del P

--- a/sim/step6_pad.py
+++ b/sim/step6_pad.py
@@ -118,12 +118,12 @@ def channel_pixels(wavelength_A,flux,N,UMAT_nm,Amatrix_rot,fmodel_generator,loca
 
   from libtbx.development.timers import Profiler
   P = Profiler("nanoBragg")
-  if add_spots_algorithm is "NKS":
+  if add_spots_algorithm=="NKS":
     from boost_adaptbx.boost.python import streambuf # will deposit printout into dummy StringIO as side effect
     SIM.add_nanoBragg_spots_nks(streambuf(StringIO()))
-  elif add_spots_algorithm is "JH":
+  elif add_spots_algorithm=="JH":
     SIM.add_nanoBragg_spots()
-  elif add_spots_algorithm is "cuda":
+  elif add_spots_algorithm=="cuda":
     SIM.add_nanoBragg_spots_cuda()
   else: raise Exception("unknown spots algorithm")
   del P


### PR DESCRIPTION
The python "is" operator tests identity, not equality. This can result in subtle bugs.
This works as expected:
```
>>> a = "cuda"
>>> if a is "cuda":
...     print("Success!")
...
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
Success!
>>>
```

This fails:
```
>>> b = "cuda2+"
>>> if b[:4] is "cuda":
...     print("Success!")
...
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
>>>
```

Fixed:
```
>>> b = "cuda2+"
>>> if b[:4]=="cuda":
...     print("Success!")
...
Success!
>>>
```