### PR TITLE
Break the DIALS/xfel circular dependency

### DIFF
--- a/adse13_187/adse13_221/tst_mask_utils.py
+++ b/adse13_187/adse13_221/tst_mask_utils.py
@@ -283,7 +283,7 @@ modeim_kernel_width=15
           writer.add_image(self.sim_mock)
 
           #Output 6. Figure the Z-plot
-          #from xfel.util import jungfrau
+          #from serialtbx.detector import jungfrau
           #RMS = jungfrau.get_pedestalRMS_from_jungfrau(self.expt)
           # the shape of RMS is 256x254x254.
           Z_plot=self.Z_statistics(experiment=self.sim_mock,


### PR DESCRIPTION
DIALS and dxtbx have had dependencies on cctbx_project/xfel, and vice versa. This PR is one of 8 that will break the cyclic dependency.

For more detail, see cctbx/cctbx_project#872