### PR TITLE
Add option to skip image saving in step5_pad.py

### DIFF
--- a/adse13_196/revapi/step5_pad.py
+++ b/adse13_196/revapi/step5_pad.py
@@ -293,7 +293,8 @@ def run_sim2smv(prefix,crystal,spectra,rotation,rank,gpu_channels_singleton,para
   del QQ
 
   extra = "PREFIX=%s;\nRANK=%d;\n"%(prefix,rank)
-  SIM.to_smv_format_py(fileout=burst_buffer_fileout,intfile_scale=1,rotmat=True,extra=extra,gz=True)
+  if not os.getenv("DONT_SAVE_IMAGES"):
+    SIM.to_smv_format_py(fileout=burst_buffer_fileout,intfile_scale=1,rotmat=True,extra=extra,gz=True)
 
   SIM.free_all()
 


### PR DESCRIPTION
Saving images can distort performance measurements; this PR adds the env variable "DONT_SAVE_IMAGES" to do exactly this.