### PR TITLE
Change open() option from "rU" to "r" for Python 3.11 compatibility.

### DIFF
--- a/sim/fdp_plot.py
+++ b/sim/fdp_plot.py
@@ -10,7 +10,7 @@ class csv:
     self.red_fdp = flex.double()
     self.ox_fp = flex.double()
     self.ox_fdp = flex.double()
-    with open("data_sherrell/FP_FDP_data.csv","rU") as F:
+    with open("data_sherrell/FP_FDP_data.csv","r") as F:
       lines = F.readlines()
       for line in lines:
         tokens = [float(f) for f in line.strip().split(",")]
@@ -36,7 +36,7 @@ class george_sherrell:
     self.energy = flex.double()
     self.fp = flex.double()
     self.fdp = flex.double()
-    with open(file,"rU") as F:
+    with open(file,"r") as F:
       lines = F.readlines()
       for line in lines:
         tokens = [float(f) for f in line.strip().split()]

--- a/work_pre_experiment/figure_fdp_plot.py
+++ b/work_pre_experiment/figure_fdp_plot.py
@@ -9,7 +9,7 @@ class csv:
     self.red_fdp = flex.double()
     self.ox_fp = flex.double()
     self.ox_fdp = flex.double()
-    with open("data_sherrell/FP_FDP_data.csv","rU") as F:
+    with open("data_sherrell/FP_FDP_data.csv","r") as F:
       lines = F.readlines()
       for line in lines:
         tokens = [float(f) for f in line.strip().split(",")]
@@ -35,7 +35,7 @@ class george_sherrell:
     self.energy = flex.double()
     self.fp = flex.double()
     self.fdp = flex.double()
-    with open(file,"rU") as F:
+    with open(file,"r") as F:
       lines = F.readlines()
       for line in lines:
         tokens = [float(f) for f in line.strip().split()]


### PR DESCRIPTION
The "U" option in open() was deprecated in the transition to python 3 and is no longer available in python 3.11. XFEL testing in Azure was failing after transitioning code to Python 3.11.