### PR TITLE
Cast channel fluxes from np.float32 to float

### DIFF
--- a/spectra/generate_spectra.py
+++ b/spectra/generate_spectra.py
@@ -151,7 +151,10 @@ class spectra_simulation:
         i_energy = offset_energy[idx]
         channel = int(i_energy - (energy-50))
         if 0 <= channel < 100:
-          channel_flux[channel] += self.R['spectra'][image][idx] * total_flux / self.average_integrated
+          # Work around a type conversion issue in numpy >=2.
+          # https://github.com/cctbx/cctbx_project/issues/1084
+          val = self.R['spectra'][image][idx] * total_flux / self.average_integrated
+          channel_flux[channel] += float(val)
       yield channel_wavelength,channel_flux,eV_to_angstrom / expected_energy
 
   def generate_recast_renormalized_image(self, image, energy, total_flux):


### PR DESCRIPTION
See https://github.com/cctbx/cctbx_project/issues/1084 and test failures such as here: https://dev.azure.com/cctbx/cctbx_project/_build/results?buildId=39151&view=logs&jobId=72337b27-feb4-5299-7d8a-94d80434839f&j=72337b27-feb4-5299-7d8a-94d80434839f&t=9a78770c-b846-55a5-c1a2-473b9b7324d5